### PR TITLE
 refactor: sidebar component

### DIFF
--- a/src/(PagesComponents)/Login.js
+++ b/src/(PagesComponents)/Login.js
@@ -174,7 +174,7 @@ const Bunker = () => {
       if (!bunkerPointer) {
         return;
       }
-      const bunker = new BunkerSigner(localKeys.privateKey, bunkerPointer, {
+      const bunker = BunkerSigner.fromBunker(localKeys.privateKey, bunkerPointer, {
         onauth: (url) => {
           window.open(
             url,
@@ -885,9 +885,8 @@ const SignupScreen = ({ switchScreen, userKeys }) => {
                     >
                       <div
                         style={{
-                          backgroundImage: `url(${
-                            picture || profilePlaceholder
-                          })`,
+                          backgroundImage: `url(${picture || profilePlaceholder
+                            })`,
                           border: "none",
                           minWidth: "128px",
                           aspectRatio: "1/1",
@@ -959,9 +958,8 @@ const SignupScreen = ({ switchScreen, userKeys }) => {
                 return (
                   <Fragment key={index}>
                     <div
-                      className={`fit-container box-pad-h box-pad-v-s fx-scattered pointer ${
-                        selectedInterest === index ? "sc-s-18" : ""
-                      }`}
+                      className={`fit-container box-pad-h box-pad-v-s fx-scattered pointer ${selectedInterest === index ? "sc-s-18" : ""
+                        }`}
                       key={index}
                       style={{ border: "none", borderRadius: "0" }}
                       onClick={() => handleSelectedInterest(index)}
@@ -1063,8 +1061,8 @@ const SignupScreen = ({ switchScreen, userKeys }) => {
                       style={{
                         borderColor:
                           showErrorMessage ||
-                          showEmptyUNMessage ||
-                          showInvalidMessage
+                            showEmptyUNMessage ||
+                            showInvalidMessage
                             ? "var(--red-main)"
                             : "",
                       }}
@@ -1301,7 +1299,7 @@ const MobileAd = () => {
             className="fit-container"
             style={{ objectFit: "contain" }}
             src={ymaHero}
-            // style={{ objectFit: "contain" }}
+          // style={{ objectFit: "contain" }}
           />
         </div>
       </div>
@@ -1426,22 +1424,22 @@ const Suggestions = ({ index, selectedInterests, handleSelectInterests }) => {
         <p className="gray-c">{t("AoO5zem")}</p>
         {isInterested?.pubkeys?.length !==
           InterestSuggestions[index].pubkeys.length && (
-          <button
-            className="btn btn-gst btn-small"
-            onClick={() => followUnfollowAll(true)}
-          >
-            {t("AzkUxnd")}
-          </button>
-        )}
+            <button
+              className="btn btn-gst btn-small"
+              onClick={() => followUnfollowAll(true)}
+            >
+              {t("AzkUxnd")}
+            </button>
+          )}
         {isInterested?.pubkeys?.length ===
           InterestSuggestions[index].pubkeys.length && (
-          <button
-            className="btn btn-normal btn-small"
-            onClick={() => followUnfollowAll(false)}
-          >
-            {t("AyohNeT")}
-          </button>
-        )}
+            <button
+              className="btn btn-normal btn-small"
+              onClick={() => followUnfollowAll(false)}
+            >
+              {t("AyohNeT")}
+            </button>
+          )}
       </div>
       <div
         className="fx-centered fx-col fx-start-h fx-start-v"

--- a/src/Components/Publishing.js
+++ b/src/Components/Publishing.js
@@ -694,7 +694,7 @@ export default function Publishing() {
         </div>
       </div>
       <div
-        className="sc-s-18 fit-container fx-centered box-marg-s pointer option link-label"
+        className="sc-s-18 fit-container fx-centered pointer option link-label"
         style={{
           backgroundColor: "transparent",
           border: failedEvents > 0 ? "1px solid var(--red-main)" : "",

--- a/src/Components/SideBar/NotificationCenter.js
+++ b/src/Components/SideBar/NotificationCenter.js
@@ -13,6 +13,7 @@ import { getCustomSettings, getWotConfig } from "@/Helpers/ClientHelpers";
 import { getWOTScoreForPubkeyLegacy, removeDuplicants } from "@/Helpers/Encryptions";
 import { setToast } from "@/Store/Slides/Publishers";
 import { localStorage_ } from "@/Helpers/utils";
+import { SidebarNavItem } from "./SidebarNavItem";
 
 export default function NotificationCenter({
   icon = false,
@@ -66,8 +67,8 @@ export default function NotificationCenter({
             let checkForLabel = event.tags.find((tag) => tag[0] === "l");
             let isUncensored = checkForLabel
               ? ["UNCENSORED NOTE RATING", "UNCENSORED NOTE"].includes(
-                  checkForLabel[1]
-                )
+                checkForLabel[1]
+              )
               : false;
             if (!isUncensored && event.pubkey !== userKeys.pub) {
               events.push(event);
@@ -179,36 +180,33 @@ export default function NotificationCenter({
   };
 
   return (
-    <>
-      <div
-        className={
-          icon
-            ? "round-icon"
-            : `pointer fit-container fx-scattered  box-pad-h-s box-pad-v-s  ${
-                isCurrent ? "active-link" : "inactive-link"
-              }`
-        }
-        style={{ position: "relative" }}
-        onClick={handleOnClick}
-      >
-        <div className="fx-centered">
-          {!isCurrent && <div className="ringbell-24"></div>}
-          {isCurrent && <div className="ringbell-bold-24"></div>}
-          {!icon && (
-            <div className={`link-label ${mobile ? "p-big" : ""}`}>
-              {t("ASSFfFZ")}
-            </div>
-          )}
-        </div>
-        {notifications !== 0 && (
-          <div className="sticker sticker-small sticker-red link-label">
-            {notifications > 99 ? `+99` : notifications}
+    <SidebarNavItem
+      className={
+        icon
+          ? "round-icon"
+          : `pointer fit-container fx-scattered  box-pad-h-s box-pad-v-s  ${isCurrent ? "active-link" : "inactive-link"
+          }`
+      }
+      style={{ position: "relative" }}
+      onClick={handleOnClick}
+    >
+      <div className="fx-centered">
+        {!isCurrent && <div className="ringbell-24"></div>}
+        {isCurrent && <div className="ringbell-bold-24"></div>}
+        {!icon && (
+          <div className={`link-label ${mobile ? "p-big" : ""}`}>
+            {t("ASSFfFZ")}
           </div>
         )}
-        {notifications !== 0 && (
-          <div className="notification-dot desk-hide-1200"></div>
-        )}
       </div>
-    </>
+      {notifications !== 0 && (
+        <div className="sticker sticker-small sticker-red link-label">
+          {notifications > 99 ? `+99` : notifications}
+        </div>
+      )}
+      {notifications !== 0 && (
+        <div className="notification-dot desk-hide-1200"></div>
+      )}
+    </SidebarNavItem>
   );
 }

--- a/src/Components/SideBar/SidebarComp.js
+++ b/src/Components/SideBar/SidebarComp.js
@@ -34,6 +34,7 @@ import SearchSidebar from "@/Components/SearchSidebar";
 import { usePathname } from "next/navigation";
 import { customHistory } from "@/Helpers/History";
 import useDirectMessages from "@/Hooks/useDirectMessages";
+import { SidebarNavItem } from "@/Components/SideBar/SidebarNavItem";
 
 export default function SidebarComp() {
   const { t } = useTranslation();
@@ -192,7 +193,7 @@ export default function SidebarComp() {
           handleOnClick={handleLogout}
         />
       )}
-      <div
+      <aside
         className="fx-scattered fx-end-v nostr-sidebar-container fx-col "
         style={{
           zIndex: isActive ? 1000 : 200,
@@ -201,10 +202,10 @@ export default function SidebarComp() {
         ref={mainFrame}
       >
         <div
-          className="nostr-sidebar fx-scattered fx-start-v fx-col fit-container"
+          className="nostr-sidebar fx-centered fx-start-h fx-col fit-container"
           style={{ height: "100%" }}
         >
-          <div className="fx-start-h fx-centered fx-col fit-container">
+          <div style={{ position: "sticky", top: 0, width: "100%" }}>
             <div className="fx-centered fx-start-h fit-container box-pad-v-s">
               <div
                 className="yakihonne-logo-128 mb-hide"
@@ -212,169 +213,133 @@ export default function SidebarComp() {
               ></div>
               <div
                 className="yaki-logomark mb-show"
-                style={{minHeight: "70px", minWidth: "70px"}}
+                style={{ minHeight: "70px", minWidth: "70px" }}
                 onClick={() => customHistory("/", true)}
               ></div>
             </div>
-            <div className="mb-show" style={{ height: "200px" }}></div>
             <UserBalance />
-            <div
-              className="fit-container link-items fx-scattered fx-col fx-start-v "
-              style={{ rowGap: 0, maxHeight: "71vh" }}
+          </div>
+          <nav
+            className="fit-container link-items fx-col fx-start-v "
+            style={{ flex: 1, overflow: "auto", overscrollBehavior: "contain", paddingBottom: '2rem' }}
+          >
+            <SidebarNavItem
+              onClick={() => {
+                customHistory("/", true);
+              }}
+              isActive={isPage("/")}
+            >
+              <div className={isPage("/") ? "home-bold-24" : "home-24"}></div>
+              <div className="link-label">{t("AJDdA3h")}</div>
+            </SidebarNavItem>
+            <SidebarNavItem
+              onClick={() => {
+                customHistory("/relay-orbits", true);
+              }}
+              isActive={isPage("/relay-orbits")}
             >
               <div
-                onClick={() => {
-                  customHistory("/", true);
-                }}
-                className={`pointer fit-container fx-start-h fx-centered box-pad-h-s box-pad-v-s ${
-                  isPage("/") ? "active-link" : "inactive-link"
-                }`}
-              >
-                <div className={isPage("/") ? "home-bold-24" : "home-24"}></div>
-                <div className="link-label">{t("AJDdA3h")}</div>
-              </div>
-              <div
-                onClick={() => {
-                  customHistory("/relay-orbits", true);
-                }}
-                className={`pointer fit-container fx-start-h fx-centered box-pad-h-s box-pad-v-s ${
-                  isPage("/relay-orbits") ? "active-link" : "inactive-link"
-                }`}
-              >
-                <div
-                  className={
-                    isPage("/relay-orbits") ? "orbit-bold-24" : "orbit-24"
-                  }
-                ></div>
-                <div className="link-label">{t("AjGFut6")}</div>
-              </div>
+                className={
+                  isPage("/relay-orbits") ? "orbit-bold-24" : "orbit-24"
+                }
+              ></div>
+              <div className="link-label">{t("AjGFut6")}</div>
+            </SidebarNavItem>
 
+            <SidebarNavItem
+              onClick={() => {
+                customHistory("/discover", true);
+              }}
+              isActive={isPage("/discover")}
+            >
               <div
-                onClick={() => {
-                  customHistory("/discover", true);
-                }}
-                // href={"/discover"}
-                className={`pointer fit-container fx-start-h fx-centered box-pad-h-s box-pad-v-s ${
-                  isPage("/discover") ? "active-link" : "inactive-link"
-                }`}
+                className={
+                  isPage("/discover") ? "discover-bold-24" : "discover-24"
+                }
+              ></div>
+              <div className="link-label">{t("ABSoIm9")}</div>
+            </SidebarNavItem>
+            <SidebarNavItem
+              onClick={() => {
+                customHistory("/smart-widgets");
+              }}
+              isActive={isPage("/smart-widgets")}
+            >
+              <div
+                className={
+                  isPage("/smart-widgets")
+                    ? "smart-widget-bold-24"
+                    : "smart-widget-24"
+                }
+              ></div>
+              <div className="link-label">{t("A2mdxcf")}</div>
+            </SidebarNavItem>
+            <SidebarNavItem
+              style={{ position: "relative" }}
+              isActive={isPage("/messages")}
+              onClick={() => customHistory("/messages")}
+            >
+              <div className="fx-centered">
+                <div
+                  className={isPage("/messages") ? "env-bold-24" : "env-24"}
+                ></div>
+                <div className="link-label">{t("As2zi6P")}</div>
+              </div>
+              {isNewMsg && <div className="notification-dot"></div>}
+            </SidebarNavItem>
+            <NotificationCenter isCurrent={isPage("/notifications")} />
+            <SearchSidebar />
+            {userKeys && (
+              <SidebarNavItem
+                isActive={isPage("/profile/" + getBech32("npub", userKeys.pub)) ||
+                  isPage("/profile/" + nip19.nprofileEncode({ pubkey: userKeys.pub })) ||
+                  isPage("/profile/" + userMetadata.nip05)}
+                onClick={handleProfileLink}
               >
                 <div
                   className={
-                    isPage("/discover") ? "discover-bold-24" : "discover-24"
-                  }
-                ></div>
-                <div className="link-label">{t("ABSoIm9")}</div>
-              </div>
-              <div
-                onClick={() => {
-                  customHistory("/smart-widgets");
-                }}
-                className={`pointer fit-container fx-start-h fx-centered box-pad-h-s box-pad-v-s ${
-                  isPage("/smart-widgets") ? "active-link" : "inactive-link"
-                }`}
-              >
-                <div
-                  className={
-                    isPage("/smart-widgets")
-                      ? "smart-widget-bold-24"
-                      : "smart-widget-24"
-                  }
-                ></div>
-                <div className="link-label">{t("A2mdxcf")}</div>
-              </div>
-              <div
-                style={{ position: "relative" }}
-                onClick={() => customHistory("/messages")}
-                className={`pointer fit-container fx-scattered box-pad-h-s box-pad-v-s ${
-                  isPage("/messages") ? "active-link" : "inactive-link"
-                }`}
-              >
-                <div className="fx-centered">
-                  <div
-                    className={isPage("/messages") ? "env-bold-24" : "env-24"}
-                  ></div>
-                  <div className="link-label">{t("As2zi6P")}</div>
-                </div>
-                {isNewMsg && <div className="notification-dot"></div>}
-              </div>
-              <NotificationCenter isCurrent={isPage("/notifications")} />
-              <SearchSidebar />
-              {userKeys && (
-                <div
-                  className="fit-container fx-centered fx-col fx-end-v"
-                  style={{
-                    position: "relative",
-                  }}
-                >
-                  <div
-                    className={`pointer fit-container fx-scattered box-pad-h-s box-pad-v-s ${
-                      isPage("/profile/" + getBech32("npub", userKeys.pub)) ||
-                      isPage(
-                        "/profile/" +
-                          nip19.nprofileEncode({ pubkey: userKeys.pub })
-                      ) ||
+                    isPage("/profile/" + getBech32("npub", userKeys.pub)) ||
+                      isPage("/profile/" + nip19.nprofileEncode({ pubkey: userKeys.pub })) ||
                       isPage("/profile/" + userMetadata.nip05)
-                        ? "active-link"
-                        : "inactive-link"
-                    }`}
-                    onClick={handleProfileLink}
-                  >
-                    <div className="fx-centered">
-                      <div
-                        className={
-                          isPage(
-                            "/profile/" + getBech32("npub", userKeys.pub)
-                          ) ||
-                          isPage(
-                            "/profile/" +
-                              nip19.nprofileEncode({ pubkey: userKeys.pub })
-                          ) ||
-                          isPage("/profile/" + userMetadata.nip05)
-                            ? "user-bold-24"
-                            : "user-24"
-                        }
-                      ></div>
-                      <div className="link-label">{t("AyBBPWE")}</div>
-                    </div>
-                  </div>
-                  <div
-                    className={`pointer fit-container fx-scattered box-pad-h-s box-pad-v-s ${
-                      isPage("/dashboard") ? "active-link" : "inactive-link"
-                    }`}
-                    onClick={() => {
-                      customHistory("/dashboard");
-                    }}
-                  >
-                    <div className="fx-centered">
-                      <div
-                        className={
-                          isPage("/dashboard")
-                            ? "dashboard-bold-24"
-                            : "dashboard-24"
-                        }
-                      ></div>
-                      <div className="link-label">{t("ALBhi3j")}</div>
-                    </div>
-                  </div>
-                </div>
-              )}
-              <YakiMobileappSidebar />
-              {/* {!userKeys && (
+                      ? "user-bold-24"
+                      : "user-24"
+                  }
+                ></div>
+                <div className="link-label">{t("AyBBPWE")}</div>
+              </SidebarNavItem>
+            )}
+            {userKeys && (
+              <SidebarNavItem
+                isActive={isPage("/dashboard")}
+                onClick={() => {
+                  customHistory("/dashboard");
+                }}
+              >
+                <div
+                  className={
+                    isPage("/dashboard")
+                      ? "dashboard-bold-24"
+                      : "dashboard-24"
+                  }
+                ></div>
+                <div className="link-label">{t("ALBhi3j")}</div>
+              </SidebarNavItem>
+            )}
+            <YakiMobileappSidebar />
+            {/* {!userKeys && (
                 <div>
                   <div className="pointer fx-centered inactive-link">
                     <DtoLToggleButton />
                   </div>
                 </div>
               )} */}
-              <div style={{ height: ".5rem" }}></div>
-              {/* {window.location.pathname !== "/dashboard" && ( */}
-              <WriteNew exit={() => null} />
-              {/* )} */}
-            </div>
-          </div>
-          <div className="fit-container">
-            <Publishing />
-            {userKeys && (
+          </nav>
+
+          <WriteNew exit={() => null} />
+
+          <Publishing />
+          <div style={{ position: "sticky", bottom: 0, width: "100%" }}>
+            {userKeys ? (
               <div
                 className="fx-scattered fx-col fit-container sidebar-user-settings "
                 style={{ position: "relative" }}
@@ -389,9 +354,9 @@ export default function SidebarComp() {
                     setShowSettings(!showSettings);
                   }}
                 >
-                    <div className="mb-show round-icon">
-                      <div className="setting-24"></div>
-                    </div>
+                  <div className="mb-show round-icon">
+                    <div className="setting-24"></div>
+                  </div>
                   <div
                     className="fx-centered fx-start-h pointer"
                     style={{ columnGap: "16px" }}
@@ -431,7 +396,7 @@ export default function SidebarComp() {
                       </p>
                     </div>
                   </div>
-                  
+
                   {isYakiChestLoaded && !yakiChestStats && (
                     <div
                       className="round-icon round-icon-tooltip orange-pulse"
@@ -502,7 +467,7 @@ export default function SidebarComp() {
                       />
                     </div>
                   )}
-                  
+
                   {!isYakiChestLoaded && <LoadingDots />}
                 </div>
                 {showSettings && (
@@ -691,23 +656,25 @@ export default function SidebarComp() {
                   </div>
                 )}
               </div>
+            ) : (
+              <button
+                className="btn btn-normal btn-full fx-centered"
+                // onClick={() => customHistory("/login")}
+                onClick={() => redirectToLogin()}
+              >
+                <div className="link-label">{t("AmOtzoL")}</div>
+                <div className="connect-24"></div>
+              </button>
             )}
           </div>
-          {!userKeys && (
-            <button
-              className="btn btn-normal btn-full fx-centered"
-              // onClick={() => customHistory("/login")}
-              onClick={() => redirectToLogin()}
-            >
-              <div className="link-label">{t("AmOtzoL")}</div>
-              <div className="connect-24"></div>
-            </button>
-          )}
+
         </div>
-      </div>
+      </aside>
     </>
   );
 }
+
+
 
 const AccountSwitching = ({ exit }) => {
   const { t } = useTranslation();

--- a/src/Components/SideBar/SidebarNavItem.jsx
+++ b/src/Components/SideBar/SidebarNavItem.jsx
@@ -1,0 +1,10 @@
+export function SidebarNavItem({ isActive, children, ...props }) {
+  return (
+    <div
+      className={`pointer fit-container fx-start-h fx-centered box-pad-h-s box-pad-v-s ${isActive ? "active-link" : "inactive-link"}`}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Make the top and bottom content of the sidebar sticky, and the middle navigation items list container scrollable

The only weird UX is that the `<Write/>` component when the user isn't connected.

| Connected? | Before | After |
| - | - | - |
| yes | <img width="1440" height="787" alt="Image" src="https://github.com/user-attachments/assets/aecc3118-24ee-4f19-bdb3-2d78ce4ee5d4" /> | <img width="1440" height="789" alt="Image" src="https://github.com/user-attachments/assets/b826bb27-d279-4f7d-ad22-27b82fbf7aa0" />|
| no | <img width="1440" height="789" alt="Image" src="https://github.com/user-attachments/assets/3d0c24c8-7953-4b13-bf97-94b8580958e3" /> | <img width="1440" height="786" alt="Image" src="https://github.com/user-attachments/assets/a473dfe3-e487-49cf-8dc6-2222c6216880" /> |

fix #7 
