### PR TITLE
feat: expose lightning invoice memo in bolt11 displays

### DIFF
--- a/src/Components/LNBCInvoice.js
+++ b/src/Components/LNBCInvoice.js
@@ -3,23 +3,29 @@ import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "react-redux";
 import ZapTip from "@/Components/ZapTip";
-import { convertDate } from "@/Helpers/Encryptions";
+import { convertDate, getInvoiceDetails } from "@/Helpers/Encryptions";
 
 export default function LNBCInvoice({ lnbc }) {
   const { t } = useTranslation();
   const userKeys = useStore((state) => state.userKeys);
   const [amount, setAmount] = useState(0);
+  const [description, setDescription] = useState(null);
   const [expiry, setExpiry] = useState(0);
   const [isDecoded, setIsDecoded] = useState(false);
 
   useEffect(() => {
     try {
+      // Decode invoice for expiry
       let decoded = decode(lnbc);
-      let a = decoded.sections.find((_) => _.name === "amount");
       let e = decoded.expiry;
-      a = a ? Math.floor(parseInt(a.value) / 1000) : "N/A";
-      setAmount(a);
       setExpiry(e * 1000 + new Date().getTime());
+
+      // Get amount and description using helper
+      const { amount: invoiceAmount, description: invoiceDesc } =
+        getInvoiceDetails(lnbc);
+      setAmount(invoiceAmount || "N/A");
+      setDescription(invoiceDesc);
+
       setIsDecoded(true);
     } catch (err) {
       console.log(err);
@@ -49,6 +55,19 @@ export default function LNBCInvoice({ lnbc }) {
     >
       <div style={{ minWidth: "50%" }}>
         <p className="gray-c">{t("AvEHTiP")}</p>
+        {description && (
+          <p
+            className="gray-c"
+            style={{
+              fontSize: "0.9rem",
+              marginTop: "0.25rem",
+              marginBottom: "0.5rem",
+              opacity: 0.8,
+            }}
+          >
+            {description}
+          </p>
+        )}
         <div className="fx-centered fx-start-h">
           <div className="bolt-bold-24"></div>
           <h3>{amount} Sats</h3>

--- a/src/Helpers/Encryptions.js
+++ b/src/Helpers/Encryptions.js
@@ -1242,6 +1242,40 @@ const filterContent = (selectedFilter, list) => {
   });
 };
 
+/**
+ * Extract amount and description from a bolt11 invoice
+ * @param {string} bolt11 - Lightning invoice string
+ * @returns {Object} Object containing amount (in sats) and description (memo)
+ */
+const getInvoiceDetails = (bolt11) => {
+  try {
+    const decoded = decode(bolt11);
+
+    // Extract amount
+    const amountSection = decoded.sections.find((_) => _.name === "amount");
+    const amount = amountSection
+      ? Math.floor(parseInt(amountSection.value) / 1000)
+      : null;
+
+    // Extract description/memo
+    const descriptionSection = decoded.sections.find(
+      (_) => _.name === "description"
+    );
+    const description = descriptionSection?.value || null;
+
+    return {
+      amount,
+      description,
+    };
+  } catch (err) {
+    console.error("Failed to decode invoice:", err);
+    return {
+      amount: null,
+      description: null,
+    };
+  }
+};
+
 export {
   getBech32,
   shortenKey,
@@ -1287,4 +1321,5 @@ export {
   getWOTScoreForPubkeyLegacy,
   getEmptyRelaysData,
   getEmptyRelaysStats,
+  getInvoiceDetails,
 };


### PR DESCRIPTION
## Summary

Modeled after [Jumble PR #643](https://github.com/CodyTseng/jumble/pull/643), this adds functionality to display invoice descriptions/memos when present in bolt11 invoices.

## Changes

- ✅ Add `getInvoiceDetails()` helper to extract both amount and description from bolt11 invoices
- ✅ Update `LNBCInvoice` component to use the new helper function  
- ✅ Display invoice memo between header and amount with muted styling
- ✅ Maintain backward compatibility with existing functionality

## Implementation Details

### New Helper Function (`src/Helpers/Encryptions.js`)
```javascript
const getInvoiceDetails = (bolt11) => {
  // Extracts both amount (in sats) and description from decoded invoice
  // Returns: { amount: number | null, description: string | null }
}
```

### Component Update (`src/Components/LNBCInvoice.js`)
- Description displays only when present in the invoice
- Styled with gray color, reduced font size (0.9rem), and opacity (0.8)
- Positioned between the "Lightning Invoice" header and the amount
- Maintains visual hierarchy with muted styling

## Benefits

- 👥 Users can now see wallet or user-generated memos in invoice cards
- 📋 Makes invoice details more complete and informative in the feed
- 🎯 Improves UX by showing payment context/purpose
- 🔄 No breaking changes to existing code

## Testing

Build compiles successfully with no errors. Invoice cards will:
- Display memo when present in bolt11 invoice
- Display normally (without memo section) when no description exists
- Maintain all existing functionality (amount, expiry, pay button)

## Reference

Implementation inspired by: https://github.com/CodyTseng/jumble/pull/643
