### PR TITLE
fix: validate pubkeys in filter.posted_by to prevent invalid NDK subscriptions

### DIFF
--- a/src/(PagesComponents)/Discover.js
+++ b/src/(PagesComponents)/Discover.js
@@ -323,10 +323,18 @@ const virtuosoRef = useRef(null);
         ? selectedFilter.to
         : lastEventsTimestamps.videos;
     let since = selectedFilter.from || undefined;
+
+    // Helper function to validate hex pubkeys (64 chars, hex only)
+    const isValidPubkey = (str) => {
+      return typeof str === 'string' && /^[0-9a-f]{64}$/i.test(str);
+    };
+
+    // Filter out invalid pubkeys (like hashtags) from posted_by
     let authors =
       selectedFilter.posted_by?.length > 0
-        ? selectedFilter.posted_by
-        : undefined;
+        ? selectedFilter.posted_by.filter(isValidPubkey)
+        : [];
+    authors = authors.length > 0 ? authors : undefined;
     if (selectedCategory.value === "top")
       return {
         artsFilter: [0, 1].includes(selectedTab)

--- a/src/(PagesComponents)/Home.js
+++ b/src/(PagesComponents)/Home.js
@@ -199,6 +199,16 @@ const HomeFeed = ({ selectedCategory, selectedFilter }) => {
         ? undefined
         : twoDaysPrior);
 
+    // Helper function to validate hex pubkeys (64 chars, hex only)
+    const isValidPubkey = (str) => {
+      return typeof str === 'string' && /^[0-9a-f]{64}$/i.test(str);
+    };
+
+    // Filter out invalid pubkeys (like hashtags) from posted_by
+    const validPostedBy = selectedFilter.posted_by?.length > 0
+      ? selectedFilter.posted_by.filter(isValidPubkey)
+      : [];
+
     let tempUserFollowings = Array.isArray(userFollowings)
       ? Array.from(userFollowings)
       : [];
@@ -216,8 +226,8 @@ const HomeFeed = ({ selectedCategory, selectedFilter }) => {
       }
 
       let authors =
-        selectedFilter.posted_by?.length > 0
-          ? selectedFilter.posted_by
+        validPostedBy.length > 0
+          ? validPostedBy
           : tempUserFollowings.length < 5
           ? [...tempUserFollowings, ...getBackupWOTList()]
           : tempUserFollowings;
@@ -233,8 +243,8 @@ const HomeFeed = ({ selectedCategory, selectedFilter }) => {
           "#l": ["smart-widget"],
           limit: 100,
           authors:
-            selectedFilter.posted_by?.length > 0
-              ? selectedFilter.posted_by
+            validPostedBy.length > 0
+              ? validPostedBy
               : undefined,
           until,
           since,
@@ -251,8 +261,8 @@ const HomeFeed = ({ selectedCategory, selectedFilter }) => {
           "#l": ["FLASH NEWS"],
           limit: 100,
           authors:
-            selectedFilter.posted_by?.length > 0
-              ? selectedFilter.posted_by
+            validPostedBy.length > 0
+              ? validPostedBy
               : undefined,
           until,
           since,
@@ -269,8 +279,8 @@ const HomeFeed = ({ selectedCategory, selectedFilter }) => {
           kinds: [1, 6],
           limit: 100,
           authors:
-            selectedFilter.posted_by?.length > 0
-              ? selectedFilter.posted_by
+            validPostedBy.length > 0
+              ? validPostedBy
               : undefined,
           until,
           since,


### PR DESCRIPTION
Adds validation to ensure only valid 64-character hex pubkeys are used in  the 'authors' field of NDK subscription filters. This prevents runtime errors  when invalid values (e.g., hashtags, interests) are incorrectly stored in  filter.posted_by from corrupted localStorage data or previous app versions.

  Affected files:
  - src/(PagesComponents)/Home.js
  - src/(PagesComponents)/Discover.js

  Fixes error: 'Filter[0].authors[N] is not a valid 64-char hex pubkey'

  This fix filters out non-hex values before they reach NDK, preventing subscription failures and improving app stability.